### PR TITLE
Pin crossbeam version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ repository = "https://github.com/stovoy/buildy"
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"
-crossbeam = "0.7.2"
+crossbeam = "=0.7.2"
 duct = "0.13.1"
 walkdir = "2"
 rust-crypto = "^0.2"


### PR DESCRIPTION
Version 0.7.3 of `crossbeam` uses 0.4.2 of `crossbeam-channel`. As `notify` depends on version `0.3.9` of `crossbeam-channel`, this ends up in a conflict of `crossbeam-channel` versions (incompatible types).

Strangely, `cargo build` would pass, but `cargo install` wouldn't.

Pinning the version of `crossbeam` fixes the issue.